### PR TITLE
Distinguish bot when emitting self

### DIFF
--- a/libraries/client.js
+++ b/libraries/client.js
@@ -435,6 +435,7 @@ function _handleTags(username, tags, cb) {
 
     self.userData = {
         username: username,
+        displayname: username,
         special: [],
         color: '#696969',
         emote: {}
@@ -442,6 +443,10 @@ function _handleTags(username, tags, cb) {
 
     if (typeof tags['color'] === 'string') {
         self.userData.color = tags['color'];
+    }
+
+    if (typeof tags['display-name'] === 'string') {
+        self.userData.displayname = tags['display-name'];
     }
 
     if (typeof tags['emotes'] === 'string') {


### PR DESCRIPTION
When the option "emitSelf" is true, there's no clear way to distinguish the bot from otherwise. (Say the account runs on the same account as the owner of the bot or as another bot) Simply passing a fourth argument to the event listeners as "from self" should be enough.

    client.addListener('chat', function(channel, user, text, fromSelf) {
        console.log('This message was', fromSelf ? '' : 'not', 'from me.');
    });