### PR TITLE
Fix excessive connection attempts

### DIFF
--- a/libraries/servers.js
+++ b/libraries/servers.js
@@ -257,8 +257,9 @@ var getServer = function getServer(client, type, server, port, cb) {
                 cb(server + ':' + serverPort);
             }
         });
+    } else {
+        return cb(serverAddress + ':' + serverPort);
     }
-    return cb(serverAddress + ':' + serverPort);
 };
 
 exports.getServer = getServer;


### PR DESCRIPTION
In my program, I had an issue where it would continually keep opening more connections to Twitch IRC.

After some digging I determined that there were numerous failed connections to connect to 'null:6667'. Every call to getServer would fire the callback correctly, and with serverAddress set to null.

Below is a snippet of output from the app, each connection attempt is approx 30s apart:

    Connected to server 192.16.64.45:6667
    Connected to server 192.16.64.146:6667
    Connected to server 199.9.248.236:6667
    Connected to server 192.16.64.144:6667
    (node) warning: possible EventEmitter memory leak detected. 11 finish listeners added. Use emitter.setMaxListeners() to increase limit.
    Trace
        at DestroyableTransform.addListener (events.js:179:15)
        at DestroyableTransform.once (events.js:204:8)
        at Socket.Readable.pipe (_stream_readable.js:580:8)
        at /.../node_modules/twitch-irc/libraries/client.js:598:21
        at /.../node_modules/twitch-irc/libraries/servers.js:259:17
        at /.../node_modules/twitch-irc/libraries/servers.js:248:36
        at /.../node_modules/twitch-irc/libraries/servers.js:122:9
        at checkConnection (/.../node_modules/twitch-irc/libraries/servers.js:64:9)
        at Socket.<anonymous> (/.../node_modules/twitch-irc/libraries/servers.js:95:9)
        at Socket.g (events.js:199:16)
